### PR TITLE
Add Semigroup concatAll intial value quiz answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,8 @@ console.log(product([1, 2, 3, 4])) // => 72
 
 **Quiz**. Why do I need to provide an initial value?
 
+-> See the [answer here](src/quiz-answers/semigroup-concatAll-initial-value.md)
+
 **Example**
 
 Lets provide some applications of `concatAll`, by reimplementing some popular functions from the JavaScript standard library.

--- a/src/quiz-answers/semigroup-concatAll-initial-value.md
+++ b/src/quiz-answers/semigroup-concatAll-initial-value.md
@@ -19,5 +19,4 @@ Why do I need to provide an initial value?
 
 ## Answer
 
-Because the array of elements can be empty.
-In that case, without the initial value, we would have to return `undefined` or `null` which would most probably not match the type of the Semigroup.
+Because there is no way to infer from the Semigroup what to do in case of an empty list. There is no way to define an `empty` value on a Semigroup. See [Monoid's concatAll below](https://github.com/enricopolanski/functional-programming/#the-concatall-function-1) to see the difference.

--- a/src/quiz-answers/semigroup-concatAll-initial-value.md
+++ b/src/quiz-answers/semigroup-concatAll-initial-value.md
@@ -1,5 +1,7 @@
 ## Question
 
+By definition `concat` combines merely two elements of `A` every time. Is it possible to combine any number of them?
+
 The `concatAll` function takes:
 
 - an instance of a semigroup
@@ -19,4 +21,15 @@ Why do I need to provide an initial value?
 
 ## Answer
 
-Because there is no way to infer from the Semigroup what to do in case of an empty list. There is no way to define an `empty` value on a Semigroup. See [Monoid's concatAll below](https://github.com/enricopolanski/functional-programming/#the-concatall-function-1) to see the difference.
+The `concatAll` method has to return an element of type `A`. If the provided array of elements is empty, we don't have any element of type `A` to return from it.
+Enforcing the need of an initial value makes sure we can return this initial value if the array is empty.
+
+We could also define a `concatAll` method which would take a `NonEmptyArray<A>` and no initial value. It's actually pretty easy to implement:
+
+```ts
+import * as S from 'fp-ts/Semigroup'
+import * as NEA from 'fp-ts/NonEmptyArray'
+
+const concatAll = <A>(S: Semigroup<A>) => (as: NEA<A>) =>
+  S.concatAll(S)(NEA.tail(as))(NEA.head(as))
+```

--- a/src/quiz-answers/semigroup-concatAll-initial-value.md
+++ b/src/quiz-answers/semigroup-concatAll-initial-value.md
@@ -1,0 +1,23 @@
+## Question
+
+The `concatAll` function takes:
+
+- an instance of a semigroup
+- an initial value
+- an array of elements
+
+```ts
+import * as S from 'fp-ts/Semigroup'
+import * as N from 'fp-ts/number'
+
+const sum = S.concatAll(N.SemigroupSum)(2)
+
+console.log(sum([1, 2, 3, 4])) // => 12
+```
+
+Why do I need to provide an initial value?
+
+## Answer
+
+Because the array of elements can be empty.
+In that case, without the initial value, we would have to return `undefined` or `null` which would most probably not match the type of the Semigroup.


### PR DESCRIPTION
Let's discuss this quiz answer with the P.R.
I had added it in the P.R. that started the quiz answers but there were on-going discussion so I removed it. Let's start again here.

@enricopolanski 's challenge was:

> Counter argument to your thesis in src/quiz-answers/semigroup-concatAll-initial-value.md, why aren't we enforcing a NonEmptyArray then?

I agree with this and, to me, this indeed would be a way to not need an initial value. I always felt like it was too much a constraint to restrict concatAll to non empty arrays but I might be wrong.
I don't see any other answer to this quiz though 😅 